### PR TITLE
Require spacemacs-theme instead of spacemacs-common

### DIFF
--- a/spacemacs-themes/ewal-spacemacs-classic-theme.el
+++ b/spacemacs-themes/ewal-spacemacs-classic-theme.el
@@ -1,10 +1,10 @@
 ;; ewal-spacemacs-classic-theme.el --- A classic, `ewal'-colored take on `spacemacs-theme'.
 
 (require 'ewal-spacemacs-themes)
-;; has to be run before loading spacemacs-common
+;; has to be run before loading spacemacs-theme
 (let ((spacemacs-theme-custom-colors
        (ewal-spacemacs-themes-get-colors t)))
-  (require 'spacemacs-common)
+  (require 'spacemacs-theme)
   (deftheme ewal-spacemacs-classic)
   (create-spacemacs-theme 'dark 'ewal-spacemacs-classic))
 

--- a/spacemacs-themes/ewal-spacemacs-modern-theme.el
+++ b/spacemacs-themes/ewal-spacemacs-modern-theme.el
@@ -1,11 +1,11 @@
 ;; ewal-spacemacs-modern-theme.el --- A modern, `ewal'-colored take on `spacemacs-theme'.
 
 (require 'ewal-spacemacs-themes)
-;; has to be run before loading `spacemacs-common'
+;; has to be run before loading `spacemacs-theme'
 (setq spacemacs-theme-org-highlight t)
 (let ((spacemacs-theme-custom-colors
        (ewal-spacemacs-themes-get-colors)))
-  (require 'spacemacs-common)
+  (require 'spacemacs-theme)
   (deftheme ewal-spacemacs-modern)
   ;; must be run before `create-spacemacs-theme'
   (ewal-spacemacs-themes--modernize-theme


### PR DESCRIPTION
"spacemacs-common.el" was renamed to "spacemacs-theme.el".

Closes #4.